### PR TITLE
Actualización de grupos

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import datetime as dt
 from dotenv import load_dotenv
 
 
@@ -73,11 +74,19 @@ if __name__ == "__main__":
         print(f"Se han encontrado {len(actual_wids)} grupos!")
         generate_toml(wid_input, actual_wids)
 
-        # Ejecuta la configuración por 1 hora
-        print("Ejecutando la configuración por 1 hora...")
+        # Ejecuta la configuración hasta las 4 AM
+        now    = dt.datetime.now()
+        future = dt.datetime(now.year, now.month, now.day, 4, 0)
+        if now.hour >= 4:
+            future += dt.timedelta(days=1)
+        wait_time = int((future-now).total_seconds())
+        print("Fecha actual:          ", now)
+        print("Fecha de actualización:", future)
+
+        print("Ejecutando la configuración hasta las 4 AM...")
         p = subprocess.Popen(matterbrige_cmd.split())
         try:
-            p.wait(60*60)
+            p.wait(wait_time)
         except subprocess.TimeoutExpired:
             p.kill()
         

--- a/searchgroups.toml
+++ b/searchgroups.toml
@@ -27,4 +27,4 @@ enable=true
 
 [[gateway.out]]
 account="whatsapp.mywhatsapp"
-channel=""
+channel="xsldjfkhsadilgdnobuefanlkasbou"


### PR DESCRIPTION
Este PR es bien simple, solo define que la lista de grupos que reciben mensajes se actualiza solo 1 vez al día y siempre a las 4AM. Se definió esta hora porque es donde menor importa que ocurra la interrupción que conlleva actualizar la lista, dado que es muy improbable que usemos la herramienta a las 4 de la mañana.

Adicionalemente, aproveché de agregar algo de feedback sobre qué en qué día ocurrió cada log.

Esto resuelve parcialmente la issue #1.