### PR TITLE
Filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ matterbridge*
 matterbridge.toml
 session-*.gob
 output.txt
+blacklist.txt
 
 
 ## DEFAULT

--- a/README.md
+++ b/README.md
@@ -40,7 +40,19 @@ Siendo el primer valor el nombre del ejecutable correspondiente a tu sistema ope
 
 Con todo lo anterior ya configurado, solo debes ejecutar:
 ```
-python3 main.py
+python3 main.py -n "[NOMBRE]"
+```
+Donde el parámetro `-n` nos permite filtrar los grupos deseados según su nombre. En `[NOMBRE]` debemos añadir una frase común contenida en todos los nombres de los grupos de llegada. Este parámetro es opcional, por lo que si ejecutas ``python3 main.py` simplemente no se aplicará el filtro.
+
+## Blacklist
+
+En un archivo `blacklist.txt` ubicado en el directorio raíz puedes agregar los WIDs de grupos que en ningún caso quieres considerar. Añádemos de la forma:
+
+``
+123456789123456789@g.us
+234567891234567891@g.us
+...
+
 ```
 
 # Referencias

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-# 
+# Constantes
 logFilename    = "output.txt"
 searchFilename = "searchgroups.toml"
 baseFilename   = "basefile.toml"
@@ -62,6 +62,17 @@ def generate_toml(wid_input, wids_output, basefile=baseFilename, outfile=tomlFil
         file.write(content)
     return content
 
+# Si existe lee la lista negra
+def read_blacklist(filename="blacklist.txt"):
+    if not os.path.exists(filename):
+        with open(filename, 'w') as file:
+            pass
+        return []
+    with open(filename, 'r') as file:
+        blacklist = [line.strip() for line in file.readlines()]
+    return blacklist
+
+
 
 
 
@@ -70,6 +81,7 @@ if __name__ == "__main__":
 
     while True:
         print("Actualizando grupos...")
+        blacklist = read_blacklist()
         os.system(search_cmd)
         with open(logFilename, 'r') as file:
             actual_wids = set()
@@ -81,6 +93,8 @@ if __name__ == "__main__":
                     wid = data[0]
                     name = ' '.join(data[1:])
                     # Añade solo grupos que cumplan el filtro
+                    if wid in blacklist:
+                        continue
                     if args.nombre:
                         if args.nombre in name:
                             actual_wids.add(wid)
@@ -91,6 +105,7 @@ if __name__ == "__main__":
         actual_wids.discard(wid_input)
         print(f"Se han encontrado {len(actual_wids)} grupos!")
         generate_toml(wid_input, actual_wids)
+
         # Ejecuta la configuración hasta las 4 AM
         now    = dt.datetime.now()
         future = dt.datetime(now.year, now.month, now.day, 4, 0)

--- a/main.py
+++ b/main.py
@@ -1,16 +1,27 @@
 import os
 import subprocess
+import argparse
 import datetime as dt
 from dotenv import load_dotenv
 
 
 
 
+# Variables de entorno
 load_dotenv()
-
 wid_input  = os.getenv('WID_INPUT')
 executable = os.getenv('EXECUTABLE')
 
+# Argumentos de línea de comandos
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-n", "--nombre",
+    help="Una frase común que deben contener todos los grupos de llegada.",
+    type=str
+)
+args = parser.parse_args()
+
+# 
 logFilename    = "output.txt"
 searchFilename = "searchgroups.toml"
 baseFilename   = "basefile.toml"

--- a/main.py
+++ b/main.py
@@ -77,14 +77,20 @@ if __name__ == "__main__":
             for line in lines:
                 if "@g.us" in line:
                     # Se accede al whatsapp id (wid)
-                    wid = line.split(' ')[2].split('"')[1]
-                    # Se añade el wid al set
-                    actual_wids.add(wid)
-        
+                    data = line.split('"')[3].split(' ')
+                    wid = data[0]
+                    name = ' '.join(data[1:])
+                    # Añade solo grupos que cumplan el filtro
+                    if args.nombre:
+                        if args.nombre in name:
+                            actual_wids.add(wid)
+                            print(f"{wid} \t {name}")
+                    else:
+                        actual_wids.add(wid)
+
         actual_wids.discard(wid_input)
         print(f"Se han encontrado {len(actual_wids)} grupos!")
         generate_toml(wid_input, actual_wids)
-
         # Ejecuta la configuración hasta las 4 AM
         now    = dt.datetime.now()
         future = dt.datetime(now.year, now.month, now.day, 4, 0)


### PR DESCRIPTION
Este PR añade funcionalidades que permiten filtrar los grupos que deseamos agregar.

Previamente siempre se agregaban todos los grupos en los que el Bot forma parte. Eso sigue siendo el comportamiento por defecto, pero ahora se puede filtrar este conjunto de dos formas:

1. Por medio de un parámetro opcional `-n`, con el cual podemos ingresar una palabra clave común en los grupos de interés. Por ejemplo:
    ```
    python3 main.py -n"natación"
    ```
    Solo añadirá grupos con nombres como: "natación los jueves", "Club de natación", etc.

2. Por medio de una lista negra. Podemos crear un archivo en el directorio raíz de nombre `blacklist.txt` que incluya en cada línea un ID de WhatsApp que queramos excluir en cualquier caso.

La exclusión de la segunda alternativa prima sobre la inclusión de la primera.